### PR TITLE
Add basic REST API using DRF

### DIFF
--- a/crime/settings.py
+++ b/crime/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
     'reports',
 ]
 
@@ -104,6 +105,14 @@ AUTH_PASSWORD_VALIDATORS = [
         'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
     },
 ]
+
+REST_FRAMEWORK = {
+    # Use Django's standard `django.contrib.auth` permissions,
+    # or allow read-only access for unauthenticated users.
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
+    ]
+}
 
 
 # Internationalization

--- a/crime/urls.py
+++ b/crime/urls.py
@@ -34,5 +34,5 @@ urlpatterns = [
     url(r'^date/(?P<year>[0-9]{4})-(?P<month>[0-9]{2})-(?P<day>[0-9]{2})/', views.date),
     url(r'^scrape/', views.do_scrape),
     url(r'^$', views.home),
-    url(r'^api/', include(router.urls)),
+    url(r'^api/v0/', include(router.urls)),
 ]

--- a/crime/urls.py
+++ b/crime/urls.py
@@ -22,6 +22,7 @@ from rest_framework import routers
 
 router = routers.DefaultRouter()
 router.register(r'users', views.UserViewSet)
+router.register(r'stations', views.StationViewSet)
 router.register(r'reports', views.ReportViewSet)
 router.register(r'incidents', views.IncidentViewSet)
 router.register(r'comments', views.CommentViewSet)

--- a/crime/urls.py
+++ b/crime/urls.py
@@ -13,10 +13,18 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url
+from django.conf.urls import url, include
 from django.contrib import admin
 
 from reports import views
+
+from rest_framework import routers
+
+router = routers.DefaultRouter()
+router.register(r'users', views.UserViewSet)
+router.register(r'reports', views.ReportViewSet)
+router.register(r'incidents', views.IncidentViewSet)
+router.register(r'comments', views.CommentViewSet)
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
@@ -26,4 +34,5 @@ urlpatterns = [
     url(r'^date/(?P<year>[0-9]{4})-(?P<month>[0-9]{2})-(?P<day>[0-9]{2})/', views.date),
     url(r'^scrape/', views.do_scrape),
     url(r'^$', views.home),
+    url(r'^api/', include(router.urls)),
 ]

--- a/reports/models.py
+++ b/reports/models.py
@@ -74,7 +74,7 @@ class Station(models.Model):
 class Incident(models.Model):
     incident_dt = models.DateTimeField(null=True, blank=True)
     incident_date = models.DateField(null=True, blank=True)
-    report = models.ForeignKey(Report)
+    report = models.ForeignKey(Report, related_name='incidents')
     station = models.ForeignKey(Station, null=True, blank=True)
     location = models.CharField(max_length=255, null=True, blank=True)
     case = models.CharField(max_length=50, null=True, blank=True)

--- a/reports/serializers.py
+++ b/reports/serializers.py
@@ -1,0 +1,24 @@
+from django.contrib.auth.models import User
+from reports.models import Report, Incident, Comment
+from rest_framework import serializers
+
+class UserSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = User
+        fields = ('url', 'username', 'first_name', 'last_name')
+
+class ReportSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Report
+        fields = ('__all__')
+
+
+class IncidentSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Incident
+        fields = ('__all__')
+
+class CommentSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Comment
+        fields = ('__all__')

--- a/reports/serializers.py
+++ b/reports/serializers.py
@@ -1,11 +1,16 @@
 from django.contrib.auth.models import User
-from reports.models import Report, Incident, Comment
+from reports.models import Report, Incident, Comment, Station
 from rest_framework import serializers
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = User
         fields = ('url', 'username', 'first_name', 'last_name')
+
+class StationSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Station
+        fields = ('__all__')
 
 class ReportSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:

--- a/reports/serializers.py
+++ b/reports/serializers.py
@@ -3,27 +3,36 @@ from reports.models import Report, Incident, Comment, Station
 from rest_framework import serializers
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
+    id = serializers.ReadOnlyField()
     class Meta:
         model = User
-        fields = ('url', 'username', 'first_name', 'last_name')
+        fields = ('id', 'url', 'username', 'first_name', 'last_name')
 
 class StationSerializer(serializers.HyperlinkedModelSerializer):
+    id = serializers.ReadOnlyField()
+
     class Meta:
         model = Station
         fields = ('__all__')
 
 class ReportSerializer(serializers.HyperlinkedModelSerializer):
+    id = serializers.ReadOnlyField()
+    incidents = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+
     class Meta:
         model = Report
         fields = ('__all__')
 
-
 class IncidentSerializer(serializers.HyperlinkedModelSerializer):
+    id = serializers.ReadOnlyField()
+
     class Meta:
         model = Incident
         fields = ('__all__')
 
 class CommentSerializer(serializers.HyperlinkedModelSerializer):
+    id = serializers.ReadOnlyField()
+
     class Meta:
         model = Comment
         fields = ('__all__')

--- a/reports/views.py
+++ b/reports/views.py
@@ -6,9 +6,12 @@ from crime import settings
 from reports.models import Report, Incident, Comment
 from reports import scraper
 
+from rest_framework import viewsets
+from reports.serializers import UserSerializer, ReportSerializer, IncidentSerializer, CommentSerializer
+
 from django.http import HttpResponse
 from django.shortcuts import render, redirect, get_object_or_404
-
+from django.contrib.auth.models import User
 from django.views.decorators.csrf import csrf_exempt
 
 @csrf_exempt
@@ -71,3 +74,32 @@ def incident(request, incident_id):
         Comment.objects.create(incident=incident, text=request.POST.get('comment'))
         return redirect('incident', incident_id=incident_id)
     return render(request, 'incident.html', {'incident': incident})
+
+class UserViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    API endpoint that allows users to be viewed or edited.
+    """
+    queryset = User.objects.all().order_by('-date_joined')
+    serializer_class = UserSerializer
+
+class ReportViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    API endpoint that allows reports to be viewed
+    """
+    queryset = Report.objects.all().order_by('-created_dt')
+    serializer_class = ReportSerializer
+
+
+class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    API endpoint that allows incidents to be viewed
+    """
+    queryset = Incident.objects.all().order_by('-incident_dt')
+    serializer_class = IncidentSerializer
+
+class CommentViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    API endpoint that allows comments to be viewed
+    """
+    queryset = Comment.objects.all().order_by('-created_dt')
+    serializer_class = CommentSerializer

--- a/reports/views.py
+++ b/reports/views.py
@@ -3,11 +3,11 @@ from __future__ import unicode_literals
 import datetime
 
 from crime import settings
-from reports.models import Report, Incident, Comment
+from reports.models import Report, Incident, Comment, Station
 from reports import scraper
 
 from rest_framework import viewsets
-from reports.serializers import UserSerializer, ReportSerializer, IncidentSerializer, CommentSerializer
+from reports.serializers import UserSerializer, StationSerializer, ReportSerializer, IncidentSerializer, CommentSerializer
 
 from django.http import HttpResponse
 from django.shortcuts import render, redirect, get_object_or_404
@@ -81,6 +81,13 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = User.objects.all().order_by('-date_joined')
     serializer_class = UserSerializer
+
+class StationViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    API endpoint that allows stations to be viewed
+    """
+    queryset = Station.objects.all().order_by('-name')
+    serializer_class = StationSerializer
 
 class ReportViewSet(viewsets.ReadOnlyModelViewSet):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ colorama==0.3.9
 decorator==4.1.1
 dj-database-url==0.4.2
 Django==1.11.3
+djangorestframework==3.6.3
 future==0.16.0
 gunicorn==19.7.1
 idna==2.5


### PR DESCRIPTION
This adds a **read-only** API using Django REST Framework for incidents, reports, comments and very basic user information (first name, last name, username).

It can be accessed under `/api/v0/`