### PR TITLE
Social sharing improvements

### DIFF
--- a/reports/admin.py
+++ b/reports/admin.py
@@ -27,7 +27,8 @@ class IncidentAdmin(admin.ModelAdmin):
     search_fields = ('title', 'case', 'bpd_id')
     ordering = ('-published_at',)
 
-    readonly_fields = ('parsed_location', 'parsed_time', 'parsed_case')
+    readonly_fields = ('parsed_location', 'parsed_time',
+                       'parsed_case', 'tweet_text')
 
     def get_queryset(self, request):
         return super(IncidentAdmin, self).get_queryset(request).prefetch_related('tags')

--- a/reports/atom_scraper.py
+++ b/reports/atom_scraper.py
@@ -139,6 +139,8 @@ def scrape(local=False, skip_existing=True,
                 if title.isupper():
                     title = title.title()
 
+                title = title.strip()
+
                 if location is not None and location.isupper():
                     location = location.title()
 

--- a/reports/tweet.py
+++ b/reports/tweet.py
@@ -2,6 +2,9 @@ import twitter
 
 from crime import settings
 
+class TwitterNotConfigured(Exception):
+    """Exception raised when Twitter is not configured."""
+    pass
 
 class Twitter:
     def __init__(self):
@@ -16,9 +19,8 @@ class Twitter:
         )
 
     def post_incident(self, incident):
-        body = '{} - {}\n----\n{}'.format(incident.title,
-                                          incident.station.name,
-                                          incident.get_url)
-        # short_desc = incident.title[:140-(len(body) - 5)]
-
-        self.api.PostUpdate(body)
+        print "Tweet text: {}".format(incident.tweet_text)
+        if self.api is not None:
+            self.api.PostUpdate(incident.tweet_text)
+        else:
+            raise TwitterNotConfigured()

--- a/templates/incident.html
+++ b/templates/incident.html
@@ -1,12 +1,15 @@
 {% extends 'base.html' %}
 {% block head %}
 <meta name="twitter:card" content="summary" />
-<meta name="twitter:title" content="{{ incident.tweet_text }}" />
+<meta name="twitter:title" content="{{ incident }}" />
 <meta name="twitter:description" content="{{ incident.body }}" />
 <meta property="og:type" content="article" />
-<meta property="og:title" content="{{ incident.tweet_text }}" />
+<meta property="og:title" content="{{ incident }}" />
 <meta property="og:description" content="{{ incident.body }}" />
-<meta property="og:updated_time" content="{{ incident.updated_time }}" />
+<meta property="article:published_time" content="{{ incident.published_at|date:'c' }}" />
+{% for tag in incident.tags.all %}<meta property="article:tags" content="{{ tag.name }}" />
+{% endfor %}
+<meta property="og:updated_time" content="{{ incident.updated_at|date:'c' }}" />
 {% endblock %}
 {% block content %}
 <h3>{{ incident.title }}</h3>
@@ -29,7 +32,7 @@
 </div>
 {% for tag in incident.tags.all %}<span class="badge badge-pill badge-default">{{ tag.name }}</span>&nbsp;{% endfor %}<br />
 <div class="share-buttons">
-  <a href="https://twitter.com/share" class="twitter-share-button" data-text="{{ incident.tweet_text }}" data-url="{{ incident.get_url }}" data-via="bart_crimes" data-related="bart_crimes" data-show-count="false">Tweet</a>
+  <a href="https://twitter.com/share" class="twitter-share-button" data-text="{{ incident }}" data-url="{{ incident.get_url }}" data-via="bart_crimes" data-related="bart_crimes" data-show-count="false">Tweet</a>
   <div class="fb-share-button" data-href="{{ incident.get_url }}" data-layout="button_count" data-size="small" data-mobile-iframe="true"><a class="fb-xfbml-parse-ignore" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u={{ incident.get_url|urlencode }}&amp;src=sdkpreparse">Share</a></div>
 </div>
 {% for comment in incident.comment_set.all %}


### PR DESCRIPTION
- Improve text used for tweets
  - Fit as much data in as we can. If default text is too long, fall back to using station abbreviation instead of full name (if station was parsed, otherwise remove the date)
- Improve Open Graph tags
  - Properly output updated at
  - Add article specific tags
- Improve Twitter Cards
- Only tweet on `post_save` if this is a brand new incident